### PR TITLE
Improve tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "broswer": "dist/VuePassword.common.js",
     "unpkg": "dist/VuePassword.umd.min.js",
     "jsDelivr": "dist/VuePassword.umd.min.js",
+    "module": "src",
+    "sideEffects": false,
     "files": [
         "dist",
         "src"
@@ -16,9 +18,6 @@
         "lint": "vue-cli-service lint",
         "test:e2e": "vue-cli-service test:e2e",
         "test:unit": "vue-cli-service test:unit"
-    },
-    "peerDependencies": {
-        "zxcvbn": "^4.4.2"
     },
     "devDependencies": {
         "@vue/cli-plugin-babel": "^3.7.0",


### PR DESCRIPTION
I was analyzing my project's build size and noticed zxcvbn being added even though I was not using vue password auto. So I made the following changes.

Adds module and sideEffects: false to package.json so webpack can safely tree
shake vue password auto [see this for more info](https://webpack.js.org/guides/tree-shaking/#conclusion). Otherwise zxcvbn is included in the final
bundle regardless if the user is using vue password auto.

Note since I made module point to just the src, the vue-loader from webpack or something similar is going to have to transform it into a JS file since it isn't like the other built files you have. I am not familiar with the vue cli build so not sure how a esm target is added. 